### PR TITLE
src/python-exec.c: utilize confstr(_CS_PATH) if PATH is unset

### DIFF
--- a/src/python-exec.c
+++ b/src/python-exec.c
@@ -84,6 +84,8 @@ int resolve_symlinks(char* outbuf, const char* path)
 	const char* sys_path;
 	const char* path_it;
 
+	char cs_path[BUFFER_SIZE];
+
 #ifndef NDEBUG
 	/* initialize the buffer with some junk
 	 * this helps catching missing null terminators */
@@ -141,7 +143,19 @@ int resolve_symlinks(char* outbuf, const char* path)
 		sys_path = getenv("PATH");
 		/* mimic exec*p() behavior */
 		if (!sys_path)
-			sys_path = "";
+		{
+			/* PATH=":${_CS_PATH}" */
+			size_t cs_len;
+			cs_path[0] = ':';
+			cs_path[1] = '\0';
+			cs_len = confstr(_CS_PATH, cs_path + 1, sizeof(cs_path) - 1);
+			if (cs_len > sizeof(cs_path) - 1)
+			{
+				fputs("_CS_PATH longer than buffer size.\n", stderr);
+				return 0;
+			}
+			sys_path = cs_path;
+		}
 
 		path_it = 0;
 	}


### PR DESCRIPTION
exec(3) from glibc says:

  The execlp(), execvp(), and execvpe() functions duplicate the actions
  of the shell in searching for an executable file if the specified
  filename does not contain a slash (/) character. The file is sought in
  the colon-separated list of directory pathnames specified in the PATH
  environment variable. If this variable isn't defined, the path list
  defaults to the current directory followed by the list of directories
  returned by confstr(_CS_PATH). (This confstr(3) call typically returns
  the value "/bin:/usr/bin".)