### PR TITLE
Use _CS_PATH as fallback PATH by default.

### DIFF
--- a/src/python-exec.c
+++ b/src/python-exec.c
@@ -140,8 +140,16 @@ int resolve_symlinks(char* outbuf, const char* path)
 
 		sys_path = getenv("PATH");
 		/* mimic exec*p() behavior */
-		if (!sys_path)
-			sys_path = FALLBACK_PATH;
+		if (!sys_path) {
+			if (strlen(FALLBACK_PATH) == 0) {
+				size_t buf_len = confstr(_CS_PATH, (char *)NULL, (size_t)0);
+				char* sys_path = malloc(buf_len);
+				confstr(_CS_PATH, sys_path, buf_len);
+			}
+			else {
+				sys_path = FALLBACK_PATH;
+			}
+		}
 
 		path_it = 0;
 	}


### PR DESCRIPTION
This allows `python-exec` to behave correct when called via `/usr/bin/env - python`.

This was discovered at https://github.com/tensorflow/tensorflow/issues/10529.

This is easily reproducible by running it:
```
$ /usr/bin/env - python
python: unable to find executable in PATH.
```

The behavior of `env` is to call `execvp` which falls back to the output of `confstr(_CS_PATH)` when no `PATH` is set. This allows `env -` to work in most cases.

However, `python-exec2c` expects `PATH` to be set and does not fall back to `confstr(_CS_PATH)` when it isn't. This change enables this behavior by default when no `FALLBACK_PATH` is provided at build time.

I've tested this on my own Gentoo. The results are positive:
```
$ /usr/bin/env - python
Python 2.7.12 (default, Aug  2 2017, 11:41:16) 
[GCC 4.9.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>>
```